### PR TITLE
Update database schema for local development without relying on having the Restarter project installed alongside.

### DIFF
--- a/database/fixometer_migrations/Version20181114113811.php
+++ b/database/fixometer_migrations/Version20181114113811.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Migrations\Fixometer;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+
+class Version20181114113811 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE users MODIFY idusers INT NOT NULL');
+        $this->addSql('ALTER TABLE users DROP PRIMARY KEY');
+        $this->addSql('ALTER TABLE users ADD updated_at DATETIME DEFAULT NULL, DROP modified_at, CHANGE role role INT NOT NULL, CHANGE idusers id INT NOT NULL');
+        $this->addSql('ALTER TABLE users ADD PRIMARY KEY (id)');
+        $this->addSql('ALTER TABLE users MODIFY id INT AUTO_INCREMENT NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE users MODIFY id INT NOT NULL');
+        $this->addSql('ALTER TABLE users DROP PRIMARY KEY');
+        $this->addSql('ALTER TABLE users ADD modified_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, DROP updated_at, CHANGE role role INT DEFAULT 3 NOT NULL, CHANGE id idusers INT NOT NULL');
+        $this->addSql('ALTER TABLE users ADD PRIMARY KEY (idusers)');
+        $this->addSql('ALTER TABLE users MODIFY idusers INT AUTO_INCREMENT NOT NULL');
+    }
+}

--- a/docker/docker-compose.testing.yml
+++ b/docker/docker-compose.testing.yml
@@ -10,6 +10,9 @@ services:
       - APP_URL=http://test.restart-project.local
 
   php:
+    depends_on:
+    - database_testing
+    - mail.restart-project.local
     environment:
       - APP_ENV=testing
       - DB_HOST=database_testing

--- a/docker/docker-compose.testing.yml
+++ b/docker/docker-compose.testing.yml
@@ -3,6 +3,9 @@ version: '2'
 services:
 
   xdebug:
+    depends_on:
+    - database_testing
+    - mail.restart-project.local
     environment:
       - APP_ENV=testing
       - DB_HOST=database_testing
@@ -21,6 +24,9 @@ services:
 
 
   composer:
+    depends_on:
+    - database_testing
+    - mail.restart-project.local
     environment:
       - APP_ENV=testing
       - DB_HOST=database_testing


### PR DESCRIPTION
This adds a new migration to the `fixometer` connection so that developers of this application can test without needing to install the Fixometer/Restarters application alongside it. 

Since the move to Laravel for the Fixometer/Restarters application, the users table has changed. This migration changes the two columns that must be updated to support the new users table schema from that application. It changes
* the `iduser` column to the `id` column and updates the `PRIMARY` index for the table,
* the `modified_at` column changed to `updated_at`.

It also updates the `role` column and removes the default value of `3` as this has changed in the metadata. 

Additionally it makes a small change to the `docker-compose.testing.yml` that ensures that the `database_testing` service is available to the `php` service by depending on it.