### PR TITLE
RESTART-63 Rename 'select category' in drop-down

### DIFF
--- a/database/fixometer_migrations/Version20181114113811.php
+++ b/database/fixometer_migrations/Version20181114113811.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Migrations\Fixometer;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+
+class Version20181114113811 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE users MODIFY idusers INT NOT NULL');
+        $this->addSql('ALTER TABLE users DROP PRIMARY KEY');
+        $this->addSql('ALTER TABLE users ADD updated_at DATETIME DEFAULT NULL, DROP modified_at, CHANGE role role INT NOT NULL, CHANGE idusers id INT NOT NULL');
+        $this->addSql('ALTER TABLE users ADD PRIMARY KEY (id)');
+        $this->addSql('ALTER TABLE users MODIFY id INT AUTO_INCREMENT NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE users MODIFY id INT NOT NULL');
+        $this->addSql('ALTER TABLE users DROP PRIMARY KEY');
+        $this->addSql('ALTER TABLE users ADD modified_at DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL, DROP updated_at, CHANGE role role INT DEFAULT 3 NOT NULL, CHANGE id idusers INT NOT NULL');
+        $this->addSql('ALTER TABLE users ADD PRIMARY KEY (idusers)');
+        $this->addSql('ALTER TABLE users MODIFY idusers INT AUTO_INCREMENT NOT NULL');
+    }
+}

--- a/docker/docker-compose.testing.yml
+++ b/docker/docker-compose.testing.yml
@@ -10,6 +10,9 @@ services:
       - APP_URL=http://test.restart-project.local
 
   php:
+    depends_on:
+    - database_testing
+    - mail.restart-project.local
     environment:
       - APP_ENV=testing
       - DB_HOST=database_testing

--- a/docker/docker-compose.testing.yml
+++ b/docker/docker-compose.testing.yml
@@ -3,6 +3,9 @@ version: '2'
 services:
 
   xdebug:
+    depends_on:
+    - database_testing
+    - mail.restart-project.local
     environment:
       - APP_ENV=testing
       - DB_HOST=database_testing
@@ -21,6 +24,9 @@ services:
 
 
   composer:
+    depends_on:
+    - database_testing
+    - mail.restart-project.local
     environment:
       - APP_ENV=testing
       - DB_HOST=database_testing

--- a/resources/lang/en/map.php
+++ b/resources/lang/en/map.php
@@ -4,7 +4,7 @@ return [
     'title' => 'Repair Directory',
     'location' => 'Where do you live?',
     'category' => 'What do you need to fix?',
-    'category_all' => 'Please select',
+    'category_all' => 'Everything',
     'search' => 'Search',
     'header_copy' => 'Find a local business to repair your broken devices.',
     'header_title' => 'Restart Repair Directory'


### PR DESCRIPTION
### Description

*People assume you have to choose a category and so renaming the option 'select a category' to none would help users to understand that this option would show all known items (I thin??)*

### Actions

I have updated the lang file so that the default label for the "everything" category is now "Everything".