### PR TITLE
RESTART-56 Add basic auditing of changes made to businesses

### DIFF
--- a/config/doctrine-mappings.php
+++ b/config/doctrine-mappings.php
@@ -122,6 +122,14 @@ return [
             'updatedAt' => [
                 'type' => 'datetime',
                 'nullable' => true
+            ],
+            'createdBy' => [
+                'type' => 'integer',
+                'nullable' => true
+            ],
+            'updatedBy' => [
+                'type' => 'integer',
+                'nullable' => true
             ]
         ]
     ],

--- a/database/migrations/Version20181121172838.php
+++ b/database/migrations/Version20181121172838.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+
+class Version20181121172838 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE businesses ADD created_by INT DEFAULT NULL, ADD updated_by INT DEFAULT NULL;');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE businesses DROP created_by, DROP updated_by;');
+    }
+}

--- a/resources/views/admin/business/edit.blade.php
+++ b/resources/views/admin/business/edit.blade.php
@@ -275,7 +275,7 @@
                         </div>
                         <div class="col-md-8">
                             @if (!empty($business->getCreatedBy()))
-                                {{ $business->getCreatedBy()->getName() }}
+                                {{ $business->getCreatedBy() }}
                             @endif
                         </div>
                     </div>
@@ -297,7 +297,7 @@
                         </div>
                         <div class="col-md-8">
                             @if (!empty($business->getUpdatedBy()))
-                                {{ $business->getUpdatedBy()->getName() }}
+                                {{ $business->getUpdatedBy() }}
                             @endif
                         </div>
                     </div>

--- a/resources/views/admin/business/edit.blade.php
+++ b/resources/views/admin/business/edit.blade.php
@@ -269,6 +269,16 @@
                         {{ $business->getCreatedAt()->format('d/m/Y H:i:s') }}
                     </div>
                 </div>
+                    <div class="row">
+                        <div class="col-md-4">
+                            Created by:
+                        </div>
+                        <div class="col-md-8">
+                            @if (!empty($business->getCreatedBy()))
+                                {{ $business->getCreatedBy()->getName() }}
+                            @endif
+                        </div>
+                    </div>
 
                 <div class="row">
                     <div class="col-md-4">
@@ -280,6 +290,17 @@
                         @endif
                     </div>
                 </div>
+
+                    <div class="row">
+                        <div class="col-md-4">
+                            Last updated by:
+                        </div>
+                        <div class="col-md-8">
+                            @if (!empty($business->getUpdatedBy()))
+                                {{ $business->getUpdatedBy()->getName() }}
+                            @endif
+                        </div>
+                    </div>
                 @endif
             </div>
 

--- a/src/Application/Commands/Business/ImportFromHttpRequest/ImportFromHttpRequestHandler.php
+++ b/src/Application/Commands/Business/ImportFromHttpRequest/ImportFromHttpRequestHandler.php
@@ -83,8 +83,14 @@ class ImportFromHttpRequestHandler
 
         $this->updateValues($business, $data);
 
+        $business->setUpdatedBy(auth()->user()->getAuthIdentifier());
         $business->setUpdatedAt(new \DateTime("now"));
+
         $business->setGeolocation($this->createPoint($data));
+
+        if (is_null($business->getCreatedBy())) {
+            $business->setCreatedBy(auth()->user()->getAuthIdentifier());
+        }
 
         if ($isCreate) {
             $this->repository->add($business);

--- a/src/Domain/Models/Business.php
+++ b/src/Domain/Models/Business.php
@@ -220,7 +220,7 @@ class Business
     private $createdAt;
 
     /**
-     * The user this business was created by
+     * The primary id of the user this business was created by
      *
      * @var User
      */
@@ -234,9 +234,9 @@ class Business
     private $updatedAt;
 
     /**
-     * The user that last updated this business
+     * The primary id of the user that last updated this business
      *
-     * @var User
+     * @var int
      */
     private $updatedBy;
 
@@ -877,7 +877,9 @@ class Business
     }
 
     /**
-     * @return User
+     * Get the primary id of the user that created this business
+     *
+     * @return int
      */
     public function getCreatedBy()
     {
@@ -886,12 +888,37 @@ class Business
 
 
     /**
-     * @return User
+     * Set the primary id of the user that created this business
+     *
+     * @param int $userId
+     */
+    public function setCreatedBy($userId)
+    {
+        $this->createdBy = $userId;
+    }
+
+
+    /**
+     * Get the primary id of the user that last updated this business
+     *
+     * @return int
      */
     public function getUpdatedBy()
     {
         return $this->updatedBy;
     }
+
+
+    /**
+     * Set the primary id of the user that last updated this business
+     *
+     * @param int $userId
+     */
+    public function setUpdatedBy($userId)
+    {
+        $this->updatedBy = $userId;
+    }
+
 
     /**
      * Return the date/time the business was last modified

--- a/src/Domain/Models/Business.php
+++ b/src/Domain/Models/Business.php
@@ -2,6 +2,7 @@
 
 namespace TheRestartProject\RepairDirectory\Domain\Models;
 
+use TheRestartProject\Fixometer\Domain\Entities\User;
 use TheRestartProject\RepairDirectory\Domain\Enums\PublishingStatus;
 
 /**
@@ -219,11 +220,25 @@ class Business
     private $createdAt;
 
     /**
+     * The user this business was created by
+     *
+     * @var User
+     */
+    private $createdBy;
+
+    /**
      * The date/time the business was last modified
      *
      * @var \DateTime
      */
     private $updatedAt;
+
+    /**
+     * The user that last updated this business
+     *
+     * @var User
+     */
+    private $updatedBy;
 
     /**
      * Return the business's unique id
@@ -861,6 +876,22 @@ class Business
         return $this->createdAt;
     }
 
+    /**
+     * @return User
+     */
+    public function getCreatedBy()
+    {
+        return $this->createdBy;
+    }
+
+
+    /**
+     * @return User
+     */
+    public function getUpdatedBy()
+    {
+        return $this->updatedBy;
+    }
 
     /**
      * Return the date/time the business was last modified


### PR DESCRIPTION
This adds to new columns to the business table, `created_by` and `updated_by` which store the IDs of the user that created the business and the last user to updated the business. 

The id of the user is outputted onto the edit view for a business in the admin section of the site as an integer. 

The updated_by field will be updated anytime a business is saved (either as part of being created or when it is updated). The created_by field will be updated only if there is no prior value (so for new businesses and pre-existing businesses only).

There is a new doctrine migration to add the new columns to the businesses table. 