### PR TITLE
REP-105 Add command to fix up bad urls in the DB

### DIFF
--- a/app/Console/Commands/FixUrls.php
+++ b/app/Console/Commands/FixUrls.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use TheRestartProject\RepairDirectory\Domain\Models\Business;
+use Doctrine\ORM\EntityManagerInterface;
+use TheRestartProject\RepairDirectory\Domain\Repositories\BusinessRepository;
+
+class FixUrls extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'fix:urls';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Fix business URLs to be in correct format';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(EntityManagerInterface $em, BusinessRepository $businessRepository)
+    {
+        $businesses = $businessRepository->findAll();
+
+        foreach ($businesses as $business) {
+            $url = $business->getWebsite();
+            $oldurl = $url;
+
+            if ($url) {
+                $url = str_replace('http://', 'https://', $url);
+
+                if (strpos($url, 'https://') === FALSE) {
+                    $url = "https://$url";
+                }
+
+                if ($url !== $oldurl) {
+                    $this->line("#" . $business->getUid() . " $oldurl => $url");
+                    $business->setWebsite($url);
+                    $em->flush();
+                }
+            }
+        }
+    }
+}

--- a/app/Console/Commands/FixUrls.php
+++ b/app/Console/Commands/FixUrls.php
@@ -24,16 +24,6 @@ class FixUrls extends Command
     protected $description = 'Fix business URLs to be in correct format';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Commands/FixUrls.php
+++ b/app/Console/Commands/FixUrls.php
@@ -47,8 +47,6 @@ class FixUrls extends Command
             $oldurl = $url;
 
             if ($url) {
-                $url = str_replace('http://', 'https://', $url);
-
                 if (strpos($url, 'https://') === FALSE) {
                     $url = "https://$url";
                 }


### PR DESCRIPTION
This fixes up http to https and adds it if not present.

This is a command rather than a migration because I suspect we may need to run this again in future.

I've fun this on map.restarters.dev:

`php artisan fix:urls`

...which fixes the case in question.