### PR TITLE
REP-96 Allow publishing of business without quality criteria

### DIFF
--- a/src/Application/Validators/CustomBusinessValidator.php
+++ b/src/Application/Validators/CustomBusinessValidator.php
@@ -114,14 +114,8 @@ class CustomBusinessValidator implements BusinessValidator
     private function validateBusinessPublishingStatus($business)
     {
         $messages = [];
-        // PublishingStatus + PositiveReviewPc
-        if ($business['publishingStatus'] === PublishingStatus::PUBLISHED && $business['positiveReviewPc'] < 80) {
-            $messages[] = 'Can\'t publish a business with a positive review percentage of under 80%';
-        }
-        // PublishingStatus + WarrantyOffered
-        if ($business['publishingStatus'] === PublishingStatus::PUBLISHED && !$business['warrantyOffered']) {
-            $messages[] = 'Can\'t publish a business that doesn\'t offer warranty.';
-        }
+
+        // We no longer place restrictions on what can be published; that is at the discretion of the administrator.
 
         if (count($messages)) {
             throw new ValidationException(implode(', ', $messages));

--- a/src/Domain/Enums/Region.php
+++ b/src/Domain/Enums/Region.php
@@ -117,16 +117,6 @@ class Region extends Enum
                 'value' => ''
             ],
             [
-                'field' => 'warrantyOffered',
-                'operator' => Operators::EQUAL,
-                'value' => true
-            ],
-            [
-                'field' => 'positiveReviewPc',
-                'operator' => Operators::GREATER_THAN_OR_EQUAL,
-                'value' => '80'
-            ],
-            [
                 'field' => 'publishingStatus',
                 'operator' => Operators::EQUAL,
                 'value' => PublishingStatus::PUBLISHED


### PR DESCRIPTION
This removes quality criteria from the publishing stage, and also from the criteria used to decide which businesses to return.

This means that the per-region criteria are now identical.  We could combine them again, but I'm included to leave this until we move the region stuff into a database, in case we change our minds.