### PR TITLE
REP-109 Add periodic website check

### DIFF
--- a/app/Console/Commands/WebsitesCheck.php
+++ b/app/Console/Commands/WebsitesCheck.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Notifications\AdminBusinessWebsiteInvalid;
+use App\Notifications\AdminNewBusinessReadyForReview;
+use Illuminate\Console\Command;
+use TheRestartProject\Fixometer\Domain\Entities\Role;
+use TheRestartProject\Fixometer\Domain\Repositories\UserRepository;
+use TheRestartProject\RepairDirectory\Application\QueryLanguage\Operators;
+use TheRestartProject\RepairDirectory\Domain\Enums\PublishingStatus;
+use TheRestartProject\RepairDirectory\Domain\Enums\Region;
+use TheRestartProject\RepairDirectory\Domain\Models\Business;
+use TheRestartProject\RepairDirectory\Domain\Repositories\BusinessRepository;
+use TheRestartProject\RepairDirectory\Domain\Services\Geocoder;
+
+class WebsitesCheck extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'websites:check';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Check business websites to see if any are no longer valid';
+
+    /**
+     * An implementation of the UserRepository
+     *
+     * @var UserRepository
+     */
+    private $userRepository;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param UserRepository $userRepository    The user repository
+     *
+     * @return void
+     */
+    public function __construct(UserRepository $userRepository)
+    {
+        $this->userRepository = $userRepository;
+
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle(BusinessRepository $repository)
+    {
+        // We only want to check businesses that we would show.
+        $criteria = [
+            [
+                'field' => 'address',
+                'operator' => Operators::NOT_EQUAL,
+                'value' => ''
+            ],
+            [
+                'field' => 'postcode',
+                'operator' => Operators::NOT_EQUAL,
+                'value' => ''
+            ],
+            [
+                'field' => 'city',
+                'operator' => Operators::NOT_EQUAL,
+                'value' => ''
+            ],
+            [
+                'field' => 'publishingStatus',
+                'operator' => Operators::EQUAL,
+                'value' => PublishingStatus::PUBLISHED
+            ]
+        ];
+
+        $businesses = $repository->findAll();
+        $this->info(count($businesses) . " businesses");
+
+        $errors = [];
+
+        foreach ($businesses as $business) {
+            $url = $business->getWebsite();
+
+            if ($url) {
+                $curl = curl_init();
+                curl_setopt($curl, CURLOPT_URL, $url);
+                curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
+                // Time out fairly fast.
+                curl_setopt($curl, CURLOPT_TIMEOUT, 60);
+
+                // Some sites require a user agent.
+                curl_setopt($curl,CURLOPT_USERAGENT,'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13');
+
+                $response = curl_exec($curl);
+                $status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+
+                if ($status !== 200 && $status !== 302) {
+                    $this->error($business->getName() . " url $url returned $status");
+
+                    $errors[] = [
+                        'uid' => $business->getUid(),
+                        'name' => $business->getName(),
+                        'url' => $url,
+                        'status' => $status,
+                    ];
+                }
+            }
+        }
+
+        if (count($errors)) {
+            $this->error("Found " . count($errors) . " errors");
+
+            $admins = $this->userRepository->findBy([
+                                                        [
+                                                            'field' => 'repairDirectoryRole',
+                                                            'operator' => Operators::EQUAL,
+                                                            'value' => Role::SUPERADMIN
+                                                        ]
+                                                    ]);
+
+            foreach ($admins as $admin) {
+                $admin->notify(new AdminBusinessWebsiteInvalid($errors));
+            }
+        }
+    }
+}

--- a/app/Notifications/AdminBusinessWebsiteInvalid.php
+++ b/app/Notifications/AdminBusinessWebsiteInvalid.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use TheRestartProject\Fixometer\Domain\Entities\User;
+use TheRestartProject\RepairDirectory\Domain\Models\Business;
+
+class AdminBusinessWebsiteInvalid extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    protected $errors;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($errors)
+    {
+        $this->errors = $errors;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        // Only email notifications supported so far - no in-app notifications.
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $msg = (new MailMessage)
+            ->subject(__('notification.business_website_invalid_subject'))
+            ->greeting(__('notification.business_website_invalid_greeting'));
+
+        foreach ($this->errors as $error) {
+            $msg->line(__('notification.business_website_invalid', $error));
+        }
+
+        return $msg;
+    }
+}

--- a/app/Providers/ScheduleServiceProvider.php
+++ b/app/Providers/ScheduleServiceProvider.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Console\Scheduling\Schedule;
+
+class ScheduleServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->app->booted(function () {
+            $schedule = $this->app->make(Schedule::class);
+            $schedule->command('websites:check')->monthly();
+        });
+    }
+
+    public function register()
+    {
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -169,8 +169,8 @@ return [
         App\Providers\SuggestionServiceProvider::class,
         App\Providers\PhantomServiceProvider::class,
         App\Providers\FixometerServiceProvider::class,
-        App\Providers\LocationServiceProvider::class
-
+        App\Providers\LocationServiceProvider::class,
+        App\Providers\ScheduleServiceProvider::class,
     ],
 
     /*

--- a/resources/lang/en/notification.php
+++ b/resources/lang/en/notification.php
@@ -4,5 +4,8 @@ return [
     'greeting' => 'Hello!',
     'business_ready_for_review_subject' => 'Repair Directory business :business set ready for review',
     'business_ready_for_review_body' => 'The Repair Directory business :business has been set ready for review by :by.',
-    'business_ready_for_review_button' => 'Review Business'
+    'business_ready_for_review_button' => 'Review Business',
+    'business_website_invalid_subject' => 'Invalid business websites',
+    'business_website_invalid_greeting' => 'The following business websites need checking',
+    'business_website_invalid' => 'Business #:uid :name url :url returned :status'
 ];


### PR DESCRIPTION
1. Introduce an artisan command to check the published websites.  This only checks HTTP return code; it doesn't check for content for holding pages.
2. Add a mail notification to handle the errors, to the superadmins.
3. Introduce a schedule service provider and schedule this job monthly.