### PR TITLE
REP-157 Make logout menu work, links to Restarters homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bootstrap": "^4.3.1",
     "cross-env": "^5.0.1",
     "font-awesome": "^4.7.0",
-    "jquery": "^3.5.0",
+    "jquery": "^3.5.1",
     "laravel-mix": "^4.0.14",
     "lodash": "^4.17.19",
     "popper.js": "^1.12",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bootstrap": "^4.3.1",
     "cross-env": "^5.0.1",
     "font-awesome": "^4.7.0",
-    "jquery": "^3.5.1",
+    "jquery": "^3.5.0",
     "laravel-mix": "^4.0.14",
     "lodash": "^4.17.19",
     "popper.js": "^1.12",

--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -49,5 +49,6 @@ return [
     'cancel' => 'Cancel',
 
     'your_profile' => 'Your profile',
+    'homepage' => 'Restarters Homepage',
     'logout' => 'Logout'
 ];

--- a/resources/views/admin/layout.blade.php
+++ b/resources/views/admin/layout.blade.php
@@ -13,9 +13,8 @@
 <body>
    <nav class="navbar navbar-expand-md navbar-light navbar-laravel">
             <div class="container">
-                <a class="navbar-brand" role="button" data-toggle="collapse" aria-expanded="false" href="#startMenu" aria-controls="startMenu" aria-label="Toggle start menu">
+                <a class="navbar-brand" role="button" href="{{ env('FIXOMETER_URL') }}" >
                     @include('admin.logo-large')
-                    <span class="caret"></span>
                 </a>
 
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
@@ -37,7 +36,7 @@
                             <li class="nav-item dropdown">
                                 @php( $user = Auth::user() )
 
-                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-target="#account-nav" aria-controls="account-nav" data-toggle="collapse" aria-haspopup="true" aria-expanded="false" aria-label="Toggle account navigation" v-pre>
+                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-target="#account-nav" aria-controls="account-nav" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" aria-label="Toggle account navigation" v-pre>
                                     {{-- @if ( isset( $user->getProfile($user->id)->path ) && !is_null( $user->getProfile($user->id)->path ) )--}}
                                     @if ( false )
                                         <img src="/uploads/thumbnail_{{ $user->getProfile($user->id)->path }}" alt="{{ $user->getName() }} Profile Picture" class="avatar">
@@ -47,17 +46,9 @@
                                     <span class="user-name">{{ $user->getName() }}</span> <span class="caret"></span>
                                 </a>
 
-                                <div id="account-nav" class="dropdown-menu collapse navbar-dropdown" aria-labelledby="navbarDropdown">
-
-                                    <ul>
-                                        <li>
-                                            <ul>
-                                                <!-- <li><a href="{{ env('FIXOMETER_URL') }}/profile/{{ Auth::id() }}">@lang('admin.your_profile')</a></li>-->
-                                                <li><a href="{{ env('FIXOMETER_URL') }}/logout">@lang('admin.logout')</a></li>
-                                            </ul>
-                                        </li>
-                                    </ul>
-
+                                <div id="account-nav" class="dropdown-menu" aria-labelledby="navbarDropdown">
+                                    <a class="dropdown-item" href="{{ env('FIXOMETER_URL') }}">@lang('admin.homepage')</a>
+                                    <a class="dropdown-item" href="{{ env('FIXOMETER_URL') }}/logout">@lang('admin.logout')</a>
                                 </div>
                             </li>
 


### PR DESCRIPTION
- There was a dropdown menu there, but it wasn't set up correctly to work with Bootstrap.  Fixed that.
- Introduced the new one for Restarters homepage.
- Added a link to the logo.
- Removed the caret next to the logo (which must be from an earlier menu system).