### PR TITLE
REP-131 Change local area to be automatically determined from the address.

### DIFF
--- a/app/Console/Commands/ImportBusinessesSpreadsheet.php
+++ b/app/Console/Commands/ImportBusinessesSpreadsheet.php
@@ -189,7 +189,8 @@ class ImportBusinessesSpreadsheet extends Command
                                 $business->setEmail($email);
                             }
 
-                            $business->setLocalArea($borough);
+                            $localArea = $repository->findLocalArea($business->getGeolocation()->getLatitude(), $business->getGeolocation()->getLongitude());
+                            $business->setLocalArea($localArea);
 
                             $business->setCategories($products);
 

--- a/app/Http/Controllers/Admin/BusinessController.php
+++ b/app/Http/Controllers/Admin/BusinessController.php
@@ -84,13 +84,15 @@ class BusinessController extends Controller
         $business = new Business();
         $business->setName($submission->getBusinessName());
         $business->setWebsite($submission->getBusinessWebsite());
-        $business->setLocalArea($submission->getBusinessBorough());
         $business->setReviewSourceUrl($submission->getReviewSource());
         $business->setNotes(
             "Submission date: " . $submission->getCreatedAt() . "\n" .
             "Submitted by employee: " . $submission->getSubmittedByEmployee() . "\n" .
             "Anything else we should know: " . $submission->getExtraInfo()
         );
+
+        // We drop the borough on the submission - this is now determined automatically from the address, and the
+        // address is supplied when we submit the creation form.
 
         return $this->renderEdit($business, []);
     }

--- a/config/doctrine-mappings.php
+++ b/config/doctrine-mappings.php
@@ -54,10 +54,6 @@ return [
                 'type' => 'string',
                 'nullable' => true
             ],
-            'localAreaName' => [
-                'type' => 'string',
-                'nullable' => true
-            ],
             'localArea' => [
                 'type' => 'integer',
                 'nullable' => true

--- a/config/doctrine-mappings.php
+++ b/config/doctrine-mappings.php
@@ -54,8 +54,12 @@ return [
                 'type' => 'string',
                 'nullable' => true
             ],
-            'localArea' => [
+            'localAreaName' => [
                 'type' => 'string',
+                'nullable' => true
+            ],
+            'localArea' => [
+                'type' => 'integer',
                 'nullable' => true
             ],
             'categories' => [

--- a/resources/js/admin.js
+++ b/resources/js/admin.js
@@ -36,10 +36,8 @@ $(document).ready(() => {
   })
 
   // set up comboboxes
-  const $localArea = $('#localArea')
   const $productsRepaired = $('#productsRepaired')
   const $authorisedBrands = $('#authorisedBrands')
-  combobox($localArea, 'localArea', false)
   combobox($productsRepaired, 'productsRepaired')
   combobox($authorisedBrands, 'authorisedBrands')
 

--- a/resources/views/admin/business/edit.blade.php
+++ b/resources/views/admin/business/edit.blade.php
@@ -59,12 +59,9 @@
             </div>
 
             <div class="form-group">
-                <label for="localArea">{{ __('admin.local_area') }}</label>
-                <input id="localArea" name="localArea" class="form-control validate" autocomplete="off"
-                       value="{{ old('localArea') ?: $business->getLocalArea() }}">
-                @if($errors->has('localArea'))
-                    <small class="business-error">{{ $errors->first('localArea') }}</small>
-                @endif
+                <label for="localAreaAuto">{{ __('admin.local_area') }}</label>
+                <input id="localAreaAuto" readonly class="form-control"
+                       value="{{ old('localAreaName') ?: $business->getLocalAreaName() }}">
             </div>
 
             <div class="form-group">

--- a/resources/views/admin/index.blade.php
+++ b/resources/views/admin/index.blade.php
@@ -39,7 +39,7 @@
                 <td>{{ $business->getName() }}</td>
                 <td>{{ $business->getAddress() }}</td>
                 <td>{{ $business->getPostcode() }}</td>
-                <td>{{ $business->getLocalArea() }}</td>
+                <td>{{ $business->getLocalAreaName() }}</td>
                 <td>{{ implode(', ', $business->getCategories()) }}</td>
                 <td>{{ $business->getNumberOfReviews() }}</td>
                 <td>{{ $business->getPositiveReviewPc() }}</td>

--- a/src/Application/Commands/Business/ImportFromCsvRow/ImportFromCsvRowHandler.php
+++ b/src/Application/Commands/Business/ImportFromCsvRow/ImportFromCsvRowHandler.php
@@ -100,7 +100,10 @@ class ImportFromCsvRowHandler
         if ($this->isTruthy($row['Email'])) {
             $business->setEmail($row['Email']);
         }
-        $business->setLocalArea($row['Borough']);
+
+        $localArea = $this->repository->findLocalArea($business->getGeolocation()->getLatitude(), $business->getGeolocation()->getLongitude());
+
+        $business->setLocalArea($localArea);
 
         try {
             $cluster = new Cluster($row['Category']);

--- a/src/Application/Commands/Business/ImportFromHttpRequest/ImportFromHttpRequestHandler.php
+++ b/src/Application/Commands/Business/ImportFromHttpRequest/ImportFromHttpRequestHandler.php
@@ -104,7 +104,14 @@ class ImportFromHttpRequestHandler
         $business->setUpdatedBy(auth()->user()->getAuthIdentifier());
         $business->setUpdatedAt(new \DateTime("now"));
 
-        $business->setGeolocation($this->createPoint($data));
+        // We need to re-geocode the address in case it's changed.
+        $point = $this->geocoder->geocode($business->getAddress() . "," . $business->getCity() . "," . $business->getPostcode());
+
+        if ($point) {
+            $business->setGeolocation($point);
+            $localArea = $this->businessRepository->findLocalArea($point->getLatitude(), $point->getLongitude());
+            $business->setLocalArea($localArea);
+        }
 
         if (is_null($business->getCreatedBy())) {
             $business->setCreatedBy(auth()->user()->getAuthIdentifier());

--- a/src/Application/Validators/CustomBusinessValidator.php
+++ b/src/Application/Validators/CustomBusinessValidator.php
@@ -59,7 +59,6 @@ class CustomBusinessValidator implements BusinessValidator
             'address' => new v\StringLengthValidator('Address', 2, 255),
             'postcode' => new v\StringLengthValidator('Postcode', 1, 64),
             'city' => new v\StringLengthValidator('City', 2, 100),
-            'localArea' => new v\StringLengthValidator('Local Area', 2, 100),
             'landline' => new v\PhoneNumberValidator('Landline'),
             'mobile' => new v\PhoneNumberValidator('Mobile'),
             'website' => new v\WebsiteValidator(),

--- a/src/Domain/Models/Business.php
+++ b/src/Domain/Models/Business.php
@@ -456,6 +456,18 @@ class Business
     }
 
     /**
+     * Set the local area name of the Business
+     *
+     * @param string $localArea
+     *
+     * @return void
+     */
+    public function setLocalAreaNAme($localArea)
+    {
+        $this->localAreaName = $localArea;
+    }
+
+    /**
      * Return the categories of product repaired by the Business
      *
      * @return array

--- a/src/Domain/Models/Business.php
+++ b/src/Domain/Models/Business.php
@@ -99,11 +99,18 @@ class Business
     private $email;
 
     /**
+     * UID of the local area
+     *
+     * @var int
+     */
+    private $localArea;
+
+    /**
      * Name of the local area, e.g. 'Brixton'
      *
      * @var string
      */
-    private $localArea;
+    private $localAreaName;
 
     /**
      * Categories of products repaired by the business, e.g. ['Desktop computer', 'Laptop']
@@ -421,6 +428,16 @@ class Business
      *
      * @return string
      */
+    public function getLocalAreaName()
+    {
+        return $this->localAreaName;
+    }
+
+    /**
+     * Return the UID of the local area of the Business
+     *
+     * @return integer
+     */
     public function getLocalArea()
     {
         return $this->localArea;
@@ -429,7 +446,7 @@ class Business
     /**
      * Set the local area of the Business
      *
-     * @param string $localArea The value to set
+     * @param integer $localArea
      *
      * @return void
      */

--- a/src/Domain/Repositories/BusinessRepository.php
+++ b/src/Domain/Repositories/BusinessRepository.php
@@ -35,7 +35,7 @@ interface BusinessRepository
      *
      * @return array
      */
-    public function findAll($user, $seeall = FALSE);
+    public function findAll($user, $seeall = false);
 
     /**
      * Finds the business or returns null
@@ -46,13 +46,13 @@ interface BusinessRepository
      *
      * @return Business|null
      */
-    public function findById($uid, $user, $seeall = FALSE);
+    public function findById($uid, $user, $seeall = false);
 
     /**
      * Finds businesses that match an array of [ property => value ].
-     * 
+     *
      * @param array $criteria The [ property => value ] array to match against businesses
-     * 
+     *
      * @return array
      */
     public function findBy($criteria);
@@ -60,9 +60,9 @@ interface BusinessRepository
     /**
      * Finds businesses within $radius miles of the provided [lat, lng]
      *
-     * @param Point   $geolocation The location to search by
-     * @param integer $radius      The radius in miles
-     * @param array   $criteria    An additional set of properties to match
+     * @param Point $geolocation The location to search by
+     * @param integer $radius The radius in miles
+     * @param array $criteria An additional set of properties to match
      *
      * @return array
      */
@@ -70,10 +70,20 @@ interface BusinessRepository
 
     /**
      * Remove a business from the repository
-     * 
+     *
      * @param Business $business The business to remove
-     * 
+     *
      * @return void
      */
     public function remove(Business $business);
+
+    /**
+     * Find the id of the area which corresponds to a lat/lng.
+     *
+     * @param float $lat
+     * @param float $lng
+     *
+     * @return integer
+     */
+    public function findLocalArea($lat, $lng);
 }

--- a/src/Infrastructure/Doctrine/Listeners/AddSuggestionsListener.php
+++ b/src/Infrastructure/Doctrine/Listeners/AddSuggestionsListener.php
@@ -92,7 +92,7 @@ class AddSuggestionsListener
             $this->addSuggestion($suggestion, $entityManager, $newSuggestions);
         }
 
-        $localArea = $business->getLocalArea();
+        $localArea = $business->getLocalAreaName();
         if ($localArea) {
             $suggestion = new Suggestion();
             $suggestion->setField('localArea');

--- a/src/Infrastructure/Doctrine/Repositories/DoctrineBusinessRepository.php
+++ b/src/Infrastructure/Doctrine/Repositories/DoctrineBusinessRepository.php
@@ -46,20 +46,29 @@ class DoctrineBusinessRepository extends DoctrineRepository implements BusinessR
      */
     public function findAll($user, $seeall = FALSE)
     {
+        $rsm = new ResultSetMappingBuilder($this->entityManager);
+        $rsm->addRootEntityFromClassMetadata(Business::class, 'b');
+
         if ($seeall || $user->isSuperAdmin()) {
             // If we are a superadmin we can see all businesses.
-            return $this->repository->findAll();
+            $sql = "SELECT b.*, AsText(b.geolocation) AS geolocation, areas.name AS local_area_name, areas.uid AS local_area FROM businesses b
+            LEFT JOIN areas ON b.local_area = areas.uid;";
+
+            $query = $this->entityManager->createNativeQuery(
+                $sql,
+                $rsm
+            );
+
+            return $query->getResult();
         } else {
             // If we are a regional admin or an editor then we can only see businesses within regions that we have been
             // assigned.
             //
             // "Within a region" means that the geolocation of the business is inside the polygon of the region.
-            $rsm = new ResultSetMappingBuilder($this->entityManager);
-            $rsm->addRootEntityFromClassMetadata(Business::class, 'b');
-
-            $sql = "SELECT b.*, AsText(b.geolocation) AS geolocation FROM businesses b
-            INNER JOIN regions ON ST_Contains(regions.polygon, b.geolocation)
+            $sql = "SELECT b.*, AsText(b.geolocation) AS geolocation, areas.name AS local_area_name, areas.uid AS local_area FROM businesses b
+            INNER JOIN regions ON ST_Contains(regions.polygon, b.geolocation)        
             INNER JOIN users_regions ON regions.uid = users_regions.region
+            LEFT JOIN areas ON b.local_area = areas.uid
             WHERE users_regions.user = " . intval($user->getUid());
 
             $query = $this->entityManager->createNativeQuery(
@@ -86,28 +95,35 @@ class DoctrineBusinessRepository extends DoctrineRepository implements BusinessR
     {
         $ret = null;
 
+        $rsm = new ResultSetMappingBuilder($this->entityManager);
+        $rsm->addRootEntityFromClassMetadata(Business::class, 'b');
+
         if ($seeall || $user->isSuperAdmin()) {
             // If we are a superadmin we can see all businesses.
-            $ret = $this->repository->find($uid);
-        } else {
-            $rsm = new ResultSetMappingBuilder($this->entityManager);
-            $rsm->addRootEntityFromClassMetadata(Business::class, 'b');
+            $sql = "SELECT b.*, AsText(b.geolocation) AS geolocation, areas.name AS local_area_name, areas.uid AS local_area FROM businesses b
+                LEFT JOIN areas ON b.local_area = areas.uid";
 
-            $sql = "SELECT b.*, AsText(b.geolocation) AS geolocation FROM businesses b
+            $query = $this->entityManager->createNativeQuery(
+                $sql,
+                $rsm
+            );
+        } else {
+            $sql = "SELECT b.*, AsText(b.geolocation) AS geolocation, areas.name AS local_area_name, areas.uid AS local_area FROM businesses b
                 INNER JOIN regions ON ST_Contains(regions.polygon, b.geolocation)
                 INNER JOIN users_regions ON regions.uid = users_regions.region
+                LEFT JOIN areas ON b.local_area = areas.uid
                 WHERE users_regions.user = " . intval($user->getUid()) . " AND b.uid = " . intval($uid);
 
             $query = $this->entityManager->createNativeQuery(
                 $sql,
                 $rsm
             );
+        }
 
-            $businesses = $query->getResult();
+        $businesses = $query->getResult();
 
-            foreach ($businesses as $business) {
-                $ret = $business;
-            }
+        foreach ($businesses as $business) {
+            $ret = $business;
         }
 
         return $ret;
@@ -136,7 +152,9 @@ class DoctrineBusinessRepository extends DoctrineRepository implements BusinessR
         $rsm = new ResultSetMappingBuilder($this->entityManager);
         $rsm->addRootEntityFromClassMetadata(Business::class, 'b0_');
 
-        $sql = "SELECT *, AsText(b0_.geolocation) AS geolocation FROM businesses b0_ WHERE 
+        $sql = "SELECT *, AsText(b0_.geolocation) AS geolocation, areas.name AS local_area_name, areas.uid AS local_area FROM businesses b0_
+                LEFT JOIN areas ON b0_.local_area = areas.uid
+                WHERE
                   MBRContains(
                     LineString(
                       Point(:x - :radius / (69 * COS(RADIANS(:y))), :y - :radius / 69),
@@ -284,5 +302,23 @@ class DoctrineBusinessRepository extends DoctrineRepository implements BusinessR
     public function remove(Business $business)
     {
         $this->entityManager->remove($business);
+    }
+
+    /**
+     * Find the id of the area which corresponds to a lat/lng.
+     *
+     * @param float $lat
+     * @param float $lng
+     *
+     * @return integer
+     */
+    public function findLocalArea($lat, $lng) {
+        $conn = $this->entityManager->getConnection();
+        $stmt = $conn->prepare("SELECT uid FROM areas WHERE ST_Contains(areas.geometry, POINT(?,?));");
+        $stmt->bindValue(1, $lng);
+        $stmt->bindValue(2, $lat);
+        $stmt->execute();
+        $res = $stmt->fetchAll();
+        return count($res) ? $res[0]['uid'] : NULL;
     }
 }

--- a/tests/Feature/Http/CreateBusinessTest.php
+++ b/tests/Feature/Http/CreateBusinessTest.php
@@ -249,7 +249,6 @@ class CreateBusinessTest extends IntegrationTestCase
             'address' => $business->getAddress(),
             'city' => $business->getCity(),
             'postcode' => $business->getPostcode(),
-            'localArea' => $business->getLocalArea(),
             'description' => $business->getDescription(),
             'landline' => $business->getLandline(),
             'mobile' => $business->getMobile(),

--- a/tests/Unit/Application/Commands/ImportFromCsvRowTest.php
+++ b/tests/Unit/Application/Commands/ImportFromCsvRowTest.php
@@ -106,7 +106,7 @@ class ImportFromCsvRowTest extends TestCase
         $this->assertEquals('12 Westgate St', $business->getAddress());
         $this->assertEquals('BA1 1EQ', $business->getPostcode());
         $this->assertEquals('Bath', $business->getCity());
-        $this->assertEquals('Bath', $business->getLocalArea());
+        $this->assertEquals('Bath', $business->getLocalAreaName());
         $this->assertEquals('01225 427538', $business->getLandline());
         $this->assertEquals('07700 900220', $business->getMobile());
         $this->assertEquals('http://irepaircentrebath.co.uk', $business->getWebsite());


### PR DESCRIPTION
Lots in this:

- Introduce the areas table, with a migration to set up the ones we use.
- Change the localArea column to be a foreign key into the areas table, and set it in the migration.
- Add/rename localAreaName, which is determined using a join.  I bypassed the Doctrine/Repository stuff for this because it was getting on my nerves - see what you think.  There's probably a Doctrine way of doing this using associations, but I think I'd have to introduce a new model for the areas and this story is already getting a bit chunky.
- Re-geocode when we save an address in case the location has changed (existing bug).
- Change the area to be a read-only field.