### PR TITLE
Check access when sending review notification to regional admins

### DIFF
--- a/app/Console/Commands/WebsitesCheck.php
+++ b/app/Console/Commands/WebsitesCheck.php
@@ -113,6 +113,9 @@ class WebsitesCheck extends Command
         if (count($errors)) {
             $this->error("Found " . count($errors) . " errors");
 
+            // Currently superadmins (i.e. a Restart team member) get notified regarding website issues.
+            // They then forward on to the relevant regional admins.
+            // In future, we may wish to split this out by regional admin.
             $admins = $this->userRepository->findBy([
                                                         [
                                                             'field' => 'repairDirectoryRole',

--- a/app/Http/Controllers/Admin/BusinessController.php
+++ b/app/Http/Controllers/Admin/BusinessController.php
@@ -36,7 +36,7 @@ class BusinessController extends Controller
 
     public function edit($id = null, BusinessRepository $repository, DoctrineUserRepository $userRepository)
     {
-        $business = $id ? $repository->findById($id, Auth::user()) : new Business();
+        $business = $id ? $repository->findBusinessForUser($id, Auth::user()) : new Business();
 
         if (!$business) {
             return response('', 404);
@@ -134,7 +134,7 @@ class BusinessController extends Controller
 
     public function delete($id, BusinessRepository $businessRepository, CommandBus $commandBus)
     {
-        $business = $businessRepository->findById($id, Auth::user());
+        $business = $businessRepository->findBusinessForUser($id, Auth::user());
         if (!$business) {
             return response('', 404);
         }

--- a/app/Http/Controllers/BusinessController.php
+++ b/app/Http/Controllers/BusinessController.php
@@ -18,7 +18,7 @@ class BusinessController extends Controller
             return response('', 403);
         }
 
-        $business = $repository->findById($id, Auth::user());
+        $business = $repository->findBusinessForUser($id, Auth::user());
 
         if (!$business) {
             return response('', 404);

--- a/src/Application/Commands/Business/ImportFromHttpRequest/ImportFromHttpRequestAuthorizer.php
+++ b/src/Application/Commands/Business/ImportFromHttpRequest/ImportFromHttpRequestAuthorizer.php
@@ -62,7 +62,7 @@ class ImportFromHttpRequestAuthorizer
         // Only authorise access to the business if we are looking at an existing business; if uid is null then
         // we are creating a business.
         if ($uid !== null) {
-            $business = $this->repository->findById($uid, Auth::user());
+            $business = $this->repository->findBusinessForUser($uid, Auth::user());
 
             if (!$business) {
                 throw new EntityNotFoundException("Business with id of {$uid} could not be found");

--- a/src/Domain/Repositories/BusinessRepository.php
+++ b/src/Domain/Repositories/BusinessRepository.php
@@ -46,7 +46,7 @@ interface BusinessRepository
      *
      * @return Business|null
      */
-    public function findById($uid, $user, $seeall = false);
+    public function findBusinessForUser($uid, $user, $seeall = false);
 
     /**
      * Finds businesses that match an array of [ property => value ].

--- a/src/Infrastructure/Doctrine/Repositories/DoctrineBusinessRepository.php
+++ b/src/Infrastructure/Doctrine/Repositories/DoctrineBusinessRepository.php
@@ -84,7 +84,7 @@ class DoctrineBusinessRepository extends DoctrineRepository implements BusinessR
     /**
      * Finds the business or returns null.
      *
-     * This will only find businesses within a region that we have access to.
+     * This will only find businesses within a region that the user has access to.
      *
      * @param integer $uid The id of the business to find
      * @param User $user
@@ -92,7 +92,7 @@ class DoctrineBusinessRepository extends DoctrineRepository implements BusinessR
      *
      * @return Business|null
      */
-    public function findById($uid, $user, $seeall = FALSE)
+    public function findBusinessForUser($uid, $user, $seeall = FALSE)
     {
         $ret = null;
 

--- a/tests/Feature/Http/Controllers/Admin/BusinessControllerTest.php
+++ b/tests/Feature/Http/Controllers/Admin/BusinessControllerTest.php
@@ -61,7 +61,7 @@ class BusinessControllerTest extends IntegrationTestCase
 
         $businessRepository = $this->app->make(BusinessRepository::class);
 
-        $this->assertEquals(new Point(51.3813963, -2.3613877), $businessRepository->findById(1, NULL, TRUE)->getGeolocation());
+        $this->assertEquals(new Point(51.3813963, -2.3613877), $businessRepository->findBusinessForUser(1, NULL, TRUE)->getGeolocation());
     }
 
     /**


### PR DESCRIPTION
* Reuse logic from notification for businesses being hidden
* Rename findById -> findBusinessForUser, as it always take user permissions in to account