### PR TITLE
Retrieve 100 Gravity Form entries, sorted by created date

### DIFF
--- a/src/Infrastructure/Services/GravityFormsSubmissionsRetriever.php
+++ b/src/Infrastructure/Services/GravityFormsSubmissionsRetriever.php
@@ -39,7 +39,10 @@ class GravityFormsSubmissionsRetriever
 
     public function retrieveAll()
     {
-        $response = $this->client->request('GET', "forms/{$this->submissionsFormId}/entries");
+        // We retrieve 100 entries, sorted by creation date, to ensure we see all recent submissions.
+        // 100 works fine for now, while submission rate is low.  If it increases significantly, we'll likely
+        // switch to an in-app form.
+        $response = $this->client->request('GET', "forms/{$this->submissionsFormId}/entries?paging[page_size]=100&sorting[key]=date_created&sorting[direction]=DESC");
         $json = json_decode($response->getBody()->getContents());
 
         $submissions = [];


### PR DESCRIPTION
Simple change, making use of the options available on the Gravity Forms /entries endpoint (https://docs.gravityforms.com/rest-api-v2/#get-entries)