### PR TITLE
REP-252 Make Mobile/Smartphone category search return results

### DIFF
--- a/app/Http/Controllers/Api/BusinessController.php
+++ b/app/Http/Controllers/Api/BusinessController.php
@@ -23,10 +23,13 @@ class BusinessController extends Controller
         $criteria = Region::CRITERIA[$region];
         
         if ($category) {
+            // The categories field is JSON-encoded, so any forward slash will be escaped.  We need to escape it here
+            // so that the LIKE matches.  But we can't add a \ as that then confuses Doctrine.  So use the single
+            // character wildcard, so that we will match \/ in the field.
             $criteria[] = [
                 'field' => 'categories',
                 'operator' => Operators::CONTAINS,
-                'value' => $category
+                'value' => str_replace('/', '_/', $category)
             ];
         }
 


### PR DESCRIPTION
We're battling Doctrine here.  

- The `categories` field is now JSON.
- That means forward slashes are now escaped with backslash.
- Doctrine doesn't escape `LIKE` correctly - see https://stackoverflow.com/questions/32584627/proper-escaping-of-like-queries-with-doctrine-querybuilder.

This PR finds a bodge that gets through Doctrine and matches.